### PR TITLE
Undo Turbolinks Change

### DIFF
--- a/lib/chartkick/helper.rb
+++ b/lib/chartkick/helper.rb
@@ -44,7 +44,7 @@ module Chartkick
       html = (options.delete(:html) || %(<div id="%{id}" style="height: %{height}; text-align: center; color: #999; line-height: %{height}; font-size: 14px; font-family: 'Lucida Grande', 'Lucida Sans Unicode', Verdana, Arial, Helvetica, sans-serif;">Loading...</div>)) % {id: ERB::Util.html_escape(element_id), height: ERB::Util.html_escape(height)}
 
       js = <<JS
-<script type="text/javascript" data-turbolinks-eval="false">
+<script type="text/javascript">
   new Chartkick.#{klass}(#{element_id.to_json}, #{data_source.respond_to?(:chart_json) ? data_source.chart_json : data_source.to_json}, #{options.to_json});
 </script>
 JS


### PR DESCRIPTION
- this caused the charts to not render when the page was loaded via
  turbo links
